### PR TITLE
Updates for Swift 1.2

### DIFF
--- a/DispatchQueue.swift
+++ b/DispatchQueue.swift
@@ -7,7 +7,7 @@ public class DispatchQueue {
 
   // MARK: Public
   
-  public let isConcurrent = false
+  public let isConcurrent: Bool
 
   public var isCurrent: Bool { return dispatch_get_specific(&kCurrentQueue) == getMutablePointer(self) }
 
@@ -34,14 +34,6 @@ public class DispatchQueue {
     }
   }
 
-  public func async (callback: @autoclosure () -> Void) {
-    async { callback() }
-  }
-
-  public func sync (callback: @autoclosure () -> Void) {
-    sync { callback() }
-  }
-
   public let dispatch_queue: dispatch_queue_t
 
 
@@ -49,6 +41,7 @@ public class DispatchQueue {
   // MARK: Internal
 
   init (_ queue: dispatch_queue_t) {
+    isConcurrent = false
     dispatch_queue = queue
     remember()
   }
@@ -73,5 +66,5 @@ public class DispatchQueue {
 var kCurrentQueue = 0
 
 func getMutablePointer (object: AnyObject) -> UnsafeMutablePointer<Void> {
-  return UnsafeMutablePointer<Void>(bitPattern: Word(ObjectIdentifier(object).uintValue()))
+  return UnsafeMutablePointer<Void>(bitPattern: Word(ObjectIdentifier(object).uintValue))
 }

--- a/DispatcherTests/DispatchTimerTests.swift
+++ b/DispatcherTests/DispatchTimerTests.swift
@@ -38,7 +38,7 @@ class DispatchTimerTests: XCTestCase {
 
   func testFire () {
   
-    timer = DispatchTimer(1, calls += 1)
+    timer = DispatchTimer(1, {self.calls += 1})
 
     timer.fire()
 
@@ -74,7 +74,7 @@ class DispatchTimerTests: XCTestCase {
   func testAutoClosureTimer () {
     let expectation = expectationWithDescription(nil)
 
-    timer = DispatchTimer(0.1, expectation.fulfill())
+    timer = DispatchTimer(0.1, {expectation.fulfill()})
 
     waitForExpectationsWithTimeout(1, handler: nil)
   }
@@ -82,21 +82,21 @@ class DispatchTimerTests: XCTestCase {
   func testAutoReleasedTimer () {
     let expectation = expectationWithDescription(nil)
 
-    DispatchTimer(0.5, expectation.fulfill()).autorelease()
+    DispatchTimer(0.5, {expectation.fulfill()}).autorelease()
 
     waitForExpectationsWithTimeout(1, handler: nil)
   }
 
   func testUnretainedTimer () {
-    DispatchTimer(0.1, calls += 1)
-    timer = DispatchTimer(0.2, XCTAssert(calls == 0))
+    DispatchTimer(0.1, {self.calls += 1})
+    timer = DispatchTimer(0.2, {XCTAssert(self.calls == 0)})
   }
 
   func testThreadSafety () {
     let expectation = expectationWithDescription(nil)
 
     gcd.async {
-      self.timer = Timer(0.5, gcd.main.sync(expectation.fulfill()))
+      self.timer = Timer(0.5, gcd.main.sync({expectation.fulfill()}))
     }
 
     waitForExpectationsWithTimeout(1, handler: nil)

--- a/DispatcherTests/DispatcherTests.swift
+++ b/DispatcherTests/DispatcherTests.swift
@@ -28,7 +28,7 @@ class DispatcherTests: XCTestCase {
   func testSyncInSync () {
     var n = 0
 
-    gcd.main.sync(gcd.main.sync(n += 1))
+    gcd.main.sync({gcd.main.sync({n += 1})})
 
     XCTAssert(n == 1)
   }
@@ -36,7 +36,7 @@ class DispatcherTests: XCTestCase {
   func testAsyncInAsync () {
     let expectation = expectationWithDescription(nil)
 
-    gcd.main.async(gcd.main.async(expectation.fulfill()))
+    gcd.main.async({gcd.main.async({expectation.fulfill()})})
 
     waitForExpectationsWithTimeout(1, handler: nil)
   }


### PR DESCRIPTION
I ran Xcode migration tool. After that, I had to apply some manual changes:

- I removed the assigned value to the <code>isConcurrent</code> <code>DispatchQueue</code> constant. It was confusing for me to see it re-assigned in the initializers
- I also assigned the <code>gcd.serial()</code> value to the <code>queue</code> constant inline with its declaration in <code>DispatchTimer</code>
- I had to remove the <code>sync</code> and <code>async</code> implementations that accept an <code>@autoclosure</code> callback in the <code>DispatchQueue</code> class because of how autoclosure works now in Swift 1.2 (in particular, <code>@autoclosure</code> implies <code>@noescape</code>, that certainly doesn't work for the <code>async</code> method, but seems to not work for the <code>sync</code> either, due to some issues with the <code>dispatch_sync</code> (that obviously doesn't mark its parameter with <code>@noescape</code> or <code>@autoclosure</code>).
- Of course I had to update the tests code to explicitly use a closure where <code>@autoclosure</code> was used before.

Let me know if you need something else

16 tests are passing.