### PR TITLE
Swift 2.0 migration, 16 tests passing

### DIFF
--- a/DispatchQueue.swift
+++ b/DispatchQueue.swift
@@ -66,5 +66,5 @@ public class DispatchQueue {
 var kCurrentQueue = 0
 
 func getMutablePointer (object: AnyObject) -> UnsafeMutablePointer<Void> {
-  return UnsafeMutablePointer<Void>(bitPattern: Word(ObjectIdentifier(object).uintValue))
+  return UnsafeMutablePointer<Void>(bitPattern: Int(ObjectIdentifier(object).uintValue))
 }

--- a/DispatchTimer.swift
+++ b/DispatchTimer.swift
@@ -39,7 +39,7 @@ public class DispatchTimer {
 
   // MARK: Instance methods
 
-  public func repeat (_ times: UInt! = nil) {
+  public func doRepeat (_ times: UInt! = nil) {
     isRepeating = true
     repeatsLeft = times != nil ? Int(times) : -1
   }

--- a/Dispatcher.xcodeproj/project.pbxproj
+++ b/Dispatcher.xcodeproj/project.pbxproj
@@ -183,6 +183,8 @@
 		1123A32E19F13F6700BF890F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftMigration = 0700;
+				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0600;
 				ORGANIZATIONNAME = Larson;
 				TargetAttributes = {

--- a/DispatcherTests/DispatchGroupTests.swift
+++ b/DispatcherTests/DispatchGroupTests.swift
@@ -13,7 +13,7 @@ class DispatchGroupTests: XCTestCase {
   }
 
   func testDispatchGroup () {
-    let expectation = expectationWithDescription(nil)
+    let expectation = expectationWithDescription("")
 
     group = DispatchGroup()
 
@@ -27,7 +27,7 @@ class DispatchGroupTests: XCTestCase {
   }
 
   func testThreadSafety () {
-    let expectation = expectationWithDescription(nil)
+    let expectation = expectationWithDescription("")
 
     group = DispatchGroup(2)
 

--- a/DispatcherTests/DispatchTimerTests.swift
+++ b/DispatcherTests/DispatchTimerTests.swift
@@ -16,7 +16,7 @@ class DispatchTimerTests: XCTestCase {
   }
 
   func testDispatchTimer () {
-    let expectation = expectationWithDescription(nil)
+    let expectation = expectationWithDescription("")
 
     timer = DispatchTimer(1, expectation.fulfill)
 
@@ -24,7 +24,7 @@ class DispatchTimerTests: XCTestCase {
   }
 
   func testCallbackQueue () {
-    let e = expectationWithDescription(nil)
+    let e = expectationWithDescription("")
     
     gcd.async {
       self.timer = DispatchTimer(0.1) {
@@ -48,31 +48,31 @@ class DispatchTimerTests: XCTestCase {
   }
 
   func testFiniteRepeatingTimer () {
-    let expectation = expectationWithDescription(nil)
+    let expectation = expectationWithDescription("")
 
     timer = DispatchTimer(0.25) {
       if ++self.calls == 2 { expectation.fulfill() }
     }
 
-    timer.repeat(2)
+    timer.doRepeat(2)
 
     waitForExpectationsWithTimeout(1, handler: nil)
   }
 
   func testInfiniteRepeatingTimer () {
-    let expectation = expectationWithDescription(nil)
+    let expectation = expectationWithDescription("")
 
     timer = DispatchTimer(0.1) {
       if ++self.calls == 5 { expectation.fulfill() }
     }
 
-    timer.repeat()
+    timer.doRepeat()
 
     waitForExpectationsWithTimeout(1, handler: nil)
   }
 
   func testAutoClosureTimer () {
-    let expectation = expectationWithDescription(nil)
+    let expectation = expectationWithDescription("")
 
     timer = DispatchTimer(0.1, {expectation.fulfill()})
 
@@ -80,7 +80,7 @@ class DispatchTimerTests: XCTestCase {
   }
 
   func testAutoReleasedTimer () {
-    let expectation = expectationWithDescription(nil)
+    let expectation = expectationWithDescription("")
 
     DispatchTimer(0.5, {expectation.fulfill()}).autorelease()
 
@@ -88,12 +88,12 @@ class DispatchTimerTests: XCTestCase {
   }
 
   func testUnretainedTimer () {
-    DispatchTimer(0.1, {self.calls += 1})
+    let _ = DispatchTimer(0.1, {self.calls += 1})
     timer = DispatchTimer(0.2, {XCTAssert(self.calls == 0)})
   }
 
   func testThreadSafety () {
-    let expectation = expectationWithDescription(nil)
+    let expectation = expectationWithDescription("")
 
     gcd.async {
       self.timer = Timer(0.5, gcd.main.sync({expectation.fulfill()}))

--- a/DispatcherTests/DispatcherTests.swift
+++ b/DispatcherTests/DispatcherTests.swift
@@ -34,7 +34,7 @@ class DispatcherTests: XCTestCase {
   }
 
   func testAsyncInAsync () {
-    let expectation = expectationWithDescription(nil)
+    let expectation = expectationWithDescription("")
 
     gcd.main.async({gcd.main.async({expectation.fulfill()})})
 


### PR DESCRIPTION
Migrated the codebase to make it compatible with `Xcode 7`, `Swift 2.0`

The only breaking change is the `repeat` function that now has to become `doRepeat` since `repeat` is a keyword in `Swift 2.0`